### PR TITLE
Treat warnings as errors

### DIFF
--- a/vs/windows.undocked.props
+++ b/vs/windows.undocked.props
@@ -194,6 +194,7 @@
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
       <AdditionalIncludeDirectories>$(IntDir);$(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <SupportJustMyCode></SupportJustMyCode> <!-- Disable /JMC -->
+      <TreatWarningAsError>true</TreatWarningAsError>
       <PreprocessorDefinitions Condition="$(UndockedKernelModeBuild)">
         KERNEL_MODE=1;
         %(ClCompile.PreprocessorDefinitions)


### PR DESCRIPTION
Treat C/C++ compiler warnings as errors by default.