### PR TITLE
Exclude .ps1 files from code signing validation policy as appropriate

### DIFF
--- a/onebranch/v1/build.yml
+++ b/onebranch/v1/build.yml
@@ -116,7 +116,7 @@ jobs:
     ${{ if eq(parameters.sign, true) }}:
       ob_sdl_codeSignValidation_excludes: -|**\*.sys # Disable signing requirements for KM builds
     ${{ if eq(parameters.sign, false) }}:
-      ob_sdl_codeSignValidation_excludes: -|**\*.sys;-|**\*.dll;-|**\*.exe # Disable signing requirements for UM & KM builds
+      ob_sdl_codeSignValidation_excludes: -|**\*.sys;-|**\*.dll;-|**\*.exe;-|**\*.ps1 # Disable signing requirements for UM & KM builds
     # https://eng.ms/docs/cloud-ai-platform/azure-edge-platform-aep/aep-engineering-systems/productivity-and-experiences/onebranch-windows-undocked/onebranch-windows-undocked/template/thingstoupdateinstartertemplate#1-windows-undocked-native-compiler-task
     ob_NativeCompiler_enabled: ${{ parameters.nativeCompiler }}
     ob_NativeCompiler_TaskVerbosity: 'Detailed'


### PR DESCRIPTION
Exclude .ps1 files from code signing validation policy if pipeline is not configured to sign

Optimistic fix for broken OneBranch pipeline in win-net-test which started failing a few weeks ago
ex: https://mscodehub.visualstudio.com/win-net-test/_build/results?buildId=457487&view=logs&j=e42c5380-e8c2-5c68-b894-317cb29b15a0&t=d60f4821-7189-51c8-6006-fdf5b23f0b25