### PR TITLE
Use NuGetCommand to restore

### DIFF
--- a/onebranch/v1/build.yml
+++ b/onebranch/v1/build.yml
@@ -138,6 +138,12 @@ jobs:
       inputs:
         targetType: inline
         script: ${{ parameters.prepareScript }}
+  - ${{ if eq(parameters.restoreNugetPackages, true) }}:
+    - task: NuGetCommand@2
+      displayName: 'Restore Nuget Packages'
+      inputs:
+        command: 'restore'
+        restoreSolution: ${{ parameters.sln }}
   - task: VSBuild@1
     displayName: Build
     target: windows_build_container
@@ -146,7 +152,6 @@ jobs:
       platform: $(ob_build_platform)
       configuration: $(ob_build_config)
       maximumCpuCount: true
-      restoreNugetPackages: ${{ parameters.restoreNugetPackages }}
       msbuildArgs: '-p:UndockedOfficial=${{ parameters.nativeCompiler }} -p:UndockedBuildId=$(Build.BuildId) ${{ parameters.msbuildArgs }}'
   - ${{ if eq(parameters.sign, true) }}:
     # https://eng.ms/docs/cloud-ai-platform/azure-edge-platform-aep/aep-engineering-systems/productivity-and-experiences/onebranch-platform-services/onebranch/signing

--- a/onebranch/v1/build.yml
+++ b/onebranch/v1/build.yml
@@ -7,7 +7,9 @@ parameters:
   prepareScript: ''
   postBuildScript: ''
   msbuildArgs: ''
+  # restoreNugetPackages deprecated. Please use nugetConfigPath.
   restoreNugetPackages: false
+  nugetConfigPath: ''
   targetOsBranch: 'official/main'
   config: 'Debug,Release'
   platform: 'x86,x64,arm64'
@@ -138,12 +140,14 @@ jobs:
       inputs:
         targetType: inline
         script: ${{ parameters.prepareScript }}
-  - ${{ if eq(parameters.restoreNugetPackages, true) }}:
+  - ${{ if ne(parameters.nugetConfigPath, '') }}:
     - task: NuGetCommand@2
       displayName: 'Restore Nuget Packages'
       inputs:
         command: 'restore'
         restoreSolution: ${{ parameters.sln }}
+        feedsToUse: 'config'
+        nugetConfigPath: ${{ parameters.nugetConfigPath }}
   - task: VSBuild@1
     displayName: Build
     target: windows_build_container
@@ -152,6 +156,7 @@ jobs:
       platform: $(ob_build_platform)
       configuration: $(ob_build_config)
       maximumCpuCount: true
+      restoreNugetPackages: ${{ parameters.restoreNugetPackages }}
       msbuildArgs: '-p:UndockedOfficial=${{ parameters.nativeCompiler }} -p:UndockedBuildId=$(Build.BuildId) ${{ parameters.msbuildArgs }}'
   - ${{ if eq(parameters.sign, true) }}:
     # https://eng.ms/docs/cloud-ai-platform/azure-edge-platform-aep/aep-engineering-systems/productivity-and-experiences/onebranch-platform-services/onebranch/signing


### PR DESCRIPTION
Add parameter to allow nuget restore during build without causing the following build/pipeline warning:
```
The 'Restore NuGet Packages' option is deprecated. To restore NuGet packages in your build, add a NuGet Tool Installer task to your build definition.
```
Existing restoreNugetPackages parameter is kept to not break existing projects

Addresses #13 
Projects must be updated to get rid of the warning