### PR TITLE
allow compiler to treat warning as error, if so configured

### DIFF
--- a/vs/windows.undocked.props
+++ b/vs/windows.undocked.props
@@ -268,7 +268,6 @@
       </PreprocessorDefinitions>
       <AdditionalOptions>
         /d1guard:xfg
-        /d1ignorePragmaWarningError
         /d1import_no_registry
         /d1nodatetime
         /d2AllowCompatibleILVersions


### PR DESCRIPTION
the `d1ignorePragmaWarningError` option causes compiler warnings to never be treated as errors, which contradicts the `<TreatWarningAsError>true</TreatWarningAsError>` property previously set in this file.