### PR TITLE
revert to VS-style platconfig by default

### DIFF
--- a/vs/windows.undocked.props
+++ b/vs/windows.undocked.props
@@ -175,7 +175,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <!-- Official Windows compiler and linker settings -->
   <PropertyGroup>
-    <UndockedPlatConfig Condition="'$(UndockedPlatConfig)' == ''">$(Platform)_$(Configuration)</UndockedVersioning>
+    <UndockedPlatConfig Condition="'$(UndockedPlatConfig)' == ''">$(Platform)_$(Configuration)</UndockedPlatConfig>
     <IntDir>$(UndockedOut)obj\$(UndockedPlatConfig)\$(ProjectName)\</IntDir>
     <OutDir>$(UndockedOut)bin\$(UndockedPlatConfig)\</OutDir>
     <UseDebugLibraries Condition="'$(Configuration)'=='Debug'">true</UseDebugLibraries>

--- a/vs/windows.undocked.props
+++ b/vs/windows.undocked.props
@@ -175,7 +175,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <!-- Official Windows compiler and linker settings -->
   <PropertyGroup>
-    <UndockedPlatConfig Condition="'$(UndockedPlatConfig)' == ''">$(Platform)_$(Configuration)</UndockedPlatConfig>
+    <UndockedPlatConfig>$(Platform)_$(Configuration)</UndockedPlatConfig>
     <IntDir>$(UndockedOut)obj\$(UndockedPlatConfig)\$(ProjectName)\</IntDir>
     <OutDir>$(UndockedOut)bin\$(UndockedPlatConfig)\</OutDir>
     <UseDebugLibraries Condition="'$(Configuration)'=='Debug'">true</UseDebugLibraries>

--- a/vs/windows.undocked.props
+++ b/vs/windows.undocked.props
@@ -175,8 +175,9 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <!-- Official Windows compiler and linker settings -->
   <PropertyGroup>
-    <IntDir>$(UndockedOut)obj\$(WinPlat)$(WinConfig)\$(ProjectName)\</IntDir>
-    <OutDir>$(UndockedOut)bin\$(WinPlat)$(WinConfig)\</OutDir>
+    <UndockedPlatConfig Condition="'$(UndockedPlatConfig)' == ''">$(Platform)_$(Configuration)</UndockedVersioning>
+    <IntDir>$(UndockedOut)obj\$(UndockedPlatConfig)\$(ProjectName)\</IntDir>
+    <OutDir>$(UndockedOut)bin\$(UndockedPlatConfig)\</OutDir>
     <UseDebugLibraries Condition="'$(Configuration)'=='Debug'">true</UseDebugLibraries>
     <UseDebugLibraries Condition="'$(Configuration)'=='Release'">false</UseDebugLibraries>
     <SignMode Condition="'$(UndockedSigning)' == 'false'">Off</SignMode>


### PR DESCRIPTION
Since we no longer need to force output directories to the Windows-internal format, use VS-style output directories by default.