### PR TITLE
use correct itemgroup macro syntax

### DIFF
--- a/vs/windows.undocked.props
+++ b/vs/windows.undocked.props
@@ -190,14 +190,14 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ResourceCompile>
-      <AdditionalIncludeDirectories>$(UndockedDir)\vs;$(IntDir);$(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(UndockedDir)\vs;$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <ClCompile>
       <SDLCheck>true</SDLCheck>
       <ControlFlowGuard>Guard</ControlFlowGuard>
       <WarningLevel>Level4</WarningLevel>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(IntDir);$(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <SupportJustMyCode></SupportJustMyCode> <!-- Disable /JMC -->
       <TreatWarningAsError>true</TreatWarningAsError>
       <PreprocessorDefinitions Condition="$(UndockedKernelModeBuild)">


### PR DESCRIPTION
The `%` character does what we want for lists of things, rather than `$` which doesn't work properly with lists.