### PR TITLE
add "none" config type

### DIFF
--- a/vs/windows.undocked.props
+++ b/vs/windows.undocked.props
@@ -134,6 +134,9 @@
     <DriverType>KMDF</DriverType>
     <UndockedKernelModeBuild>true</UndockedKernelModeBuild>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(UndockedType)' == 'none'">
+    <ConfigurationType>none</ConfigurationType>
+  </PropertyGroup>
   <!-- Calculate version properties for resource compile -->
   <Target Name="VersionProperties" BeforeTargets="ClCompile;ResourceCompile" Condition="'$(UndockedVersioning)'!='false'">
     <Exec Command="git describe --long --always --exclude=* --abbrev=8" ConsoleToMSBuild="True" IgnoreExitCode="False">


### PR DESCRIPTION
Add a "none" configuration type that explicitly does not create any c++ targets. This can be used for projects that build artifacts using other tools.