### PR TITLE
isolate nuget-generated props files into obj dir

### DIFF
--- a/vs/windows.undocked.props
+++ b/vs/windows.undocked.props
@@ -17,9 +17,6 @@
     <UndockedBuildArm64x Condition="'$(UndockedBuildArm64x)' == '' OR $(ARM64X_DISABLED) == '1'">false</UndockedBuildArm64x>
     <!-- Use the official LKG complier when available -->
     <UseInternalMSUniCrtPackage>true</UseInternalMSUniCrtPackage>
-    <UndockedPlatConfig Condition="'$(UndockedPlatConfig)' == ''">$(Platform)_$(Configuration)</UndockedPlatConfig>
-    <_IntDir>$(UndockedOut)obj\$(UndockedPlatConfig)\$(MSBuildProjectName)\</_IntDir>
-    <MSBuildProjectExtensionsPath Condition="'$(MSBuildProjectExtensionsPath)' == ''">$(_IntDir)</MSBuildProjectExtensionsPath>
   </PropertyGroup>
   <!-- The set of supported user mode configurations (x86,x64,arm,arm64) -->
   <ItemGroup Label="ProjectConfigurations" Condition="'$(UndockedType)' != 'sys'">
@@ -105,6 +102,9 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
     <Keyword>Win32Proj</Keyword>
+    <UndockedPlatConfig Condition="'$(UndockedPlatConfig)' == ''">$(Platform)_$(Configuration)</UndockedPlatConfig>
+    <_IntDir>$(UndockedOut)obj\$(UndockedPlatConfig)\$(MSBuildProjectName)\</_IntDir>
+    <MSBuildProjectExtensionsPath Condition="'$(MSBuildProjectExtensionsPath)' == ''">$(_IntDir)</MSBuildProjectExtensionsPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(UndockedUseDriverToolset)' == 'false'">
     <PlatformToolset>v143</PlatformToolset>

--- a/vs/windows.undocked.props
+++ b/vs/windows.undocked.props
@@ -17,6 +17,9 @@
     <UndockedBuildArm64x Condition="'$(UndockedBuildArm64x)' == '' OR $(ARM64X_DISABLED) == '1'">false</UndockedBuildArm64x>
     <!-- Use the official LKG complier when available -->
     <UseInternalMSUniCrtPackage>true</UseInternalMSUniCrtPackage>
+    <UndockedPlatConfig Condition="'$(UndockedPlatConfig)' == ''">$(Platform)_$(Configuration)</UndockedPlatConfig>
+    <_IntDir>$(UndockedOut)obj\$(UndockedPlatConfig)\$(MSBuildProjectName)\</_IntDir>
+    <MSBuildProjectExtensionsPath Condition="'$(MSBuildProjectExtensionsPath)' == ''">$(_IntDir)</MSBuildProjectExtensionsPath>
   </PropertyGroup>
   <!-- The set of supported user mode configurations (x86,x64,arm,arm64) -->
   <ItemGroup Label="ProjectConfigurations" Condition="'$(UndockedType)' != 'sys'">
@@ -178,8 +181,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <!-- Official Windows compiler and linker settings -->
   <PropertyGroup>
-    <UndockedPlatConfig>$(Platform)_$(Configuration)</UndockedPlatConfig>
-    <IntDir>$(UndockedOut)obj\$(UndockedPlatConfig)\$(ProjectName)\</IntDir>
+    <IntDir>$(_IntDir)</IntDir>
     <OutDir>$(UndockedOut)bin\$(UndockedPlatConfig)\</OutDir>
     <UseDebugLibraries Condition="'$(Configuration)'=='Debug'">true</UseDebugLibraries>
     <UseDebugLibraries Condition="'$(Configuration)'=='Release'">false</UseDebugLibraries>


### PR DESCRIPTION
By default, nuget restore dumps a pile of properties into an obj subdirectory of each project's directory, which is not aligned to the  undocked IntDir/OutDir model. Fix that.