### PR TITLE
move msbuild extension files into separate dirs

### DIFF
--- a/vs/windows.undocked.props
+++ b/vs/windows.undocked.props
@@ -103,8 +103,7 @@
     <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
     <Keyword>Win32Proj</Keyword>
     <UndockedPlatConfig Condition="'$(UndockedPlatConfig)' == ''">$(Platform)_$(Configuration)</UndockedPlatConfig>
-    <_IntDir>$(UndockedOut)obj\$(UndockedPlatConfig)\$(MSBuildProjectName)\</_IntDir>
-    <MSBuildProjectExtensionsPath Condition="'$(MSBuildProjectExtensionsPath)' == ''">$(_IntDir)</MSBuildProjectExtensionsPath>
+    <MSBuildProjectExtensionsPath Condition="'$(MSBuildProjectExtensionsPath)' == ''">$(UndockedOut)obj\$(UndockedPlatConfig)\msbuildext\$(MSBuildProjectName)\</MSBuildProjectExtensionsPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(UndockedUseDriverToolset)' == 'false'">
     <PlatformToolset>v143</PlatformToolset>
@@ -181,7 +180,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <!-- Official Windows compiler and linker settings -->
   <PropertyGroup>
-    <IntDir>$(_IntDir)</IntDir>
+    <IntDir>$(UndockedOut)obj\$(UndockedPlatConfig)\$(MSBuildProjectName)\</IntDir>
     <OutDir>$(UndockedOut)bin\$(UndockedPlatConfig)\</OutDir>
     <UseDebugLibraries Condition="'$(Configuration)'=='Debug'">true</UseDebugLibraries>
     <UseDebugLibraries Condition="'$(Configuration)'=='Release'">false</UseDebugLibraries>


### PR DESCRIPTION
The newest WDKs exposed an unfortunate problem: because autogenerated nuget files were being placed into `IntDir`, they were getting cleaned up during builds. Move these extension files into their own, safe directory.