### PR TITLE
Set msbuild.exe arch to x64 to avoid issues with nuget wdk

### DIFF
--- a/onebranch/v1/build.yml
+++ b/onebranch/v1/build.yml
@@ -156,6 +156,7 @@ jobs:
       platform: $(ob_build_platform)
       configuration: $(ob_build_config)
       maximumCpuCount: true
+      msbuildArchitecture: x64
       msbuildArgs: '-p:UndockedOfficial=${{ parameters.nativeCompiler }} -p:UndockedBuildId=$(Build.BuildId) ${{ parameters.msbuildArgs }}'
   - ${{ if eq(parameters.sign, true) }}:
     # https://eng.ms/docs/cloud-ai-platform/azure-edge-platform-aep/aep-engineering-systems/productivity-and-experiences/onebranch-platform-services/onebranch/signing


### PR DESCRIPTION
This pull request includes a change to the `jobs` section in the `onebranch/v1/build.yml` file to specify the architecture for MSBuild. 

* [`onebranch/v1/build.yml`](diffhunk://#diff-1bdd78191c9107174dcd3944cda02b0ce1397fe1e3c82ecd2050b59b24bb29faR159): Added `msbuildArchitecture: x64` to ensure that MSBuild uses the x64 architecture during the build process.