### PR TITLE
Change UcrtPlatform to use build platform variable

### DIFF
--- a/onebranch/v1/build.yml
+++ b/onebranch/v1/build.yml
@@ -124,7 +124,7 @@ jobs:
     ob_NativeCompiler_TaskVerbosity: 'Detailed'
     ob_NativeCompiler_UseOSBranchVersion: true
     ob_NativeCompiler_TargetOsBranch: ${{ parameters.targetOsBranch }}
-    ob_NativeCompiler_UcrtPlatform: 'amd64'
+    ob_NativeCompiler_UcrtPlatform: '$(ob_build_platform_win)'
     # https://eng.ms/docs/cloud-ai-platform/azure-edge-platform-aep/aep-engineering-systems/productivity-and-experiences/onebranch-windows-undocked/onebranch-windows-undocked/template/thingstoupdateinstartertemplate#2-set-feature-flags---createvpack-and-updateosmanifest
     ${{ if eq(parameters.package, true) }}:
       ob_createvpack_enabled: true


### PR DESCRIPTION
According to this IcM:
https://portal.microsofticm.com/imp/v5/incidents/details/664101348/summary?tmpl=F1R1x2

The uCRT platform must match the platform of the build.   If building arm64 then the uCRT must be arm64, etc.   

The pipeline you have is very close to being correct.  The only thing that needs to change is this variable

 ob_NativeCompiler_UcrtPlatform: 'amd64'

Instead of explicit setting to 'amd64' use one of the matrix values that is generated.  See  the ob_build_platform_win values in the strategy matrix.

The uCRT Platform can be any of the following: amd64, arm64, x86.

So that variable could be set to 
 ob_NativeCompiler_UcrtPlatform:  $(ob_build_platform_win)